### PR TITLE
FIX: BatteryUnit minP and maxP to be related with pctCharge and pctDischarge

### DIFF
--- a/ravens/xml/opendss2xml.py
+++ b/ravens/xml/opendss2xml.py
@@ -842,8 +842,8 @@ class DssExport(object):
     def _add_BatteryUnit(self, subject_uri: URIRef, storage: object):
         node = self.build_cim_obj("BatteryUnit", name=f"{storage.Name}_Cells")
 
-        self.add_triple(node, "PowerElectronicsUnit.minP", storage.kWRated * storage.pctkWRated / 100.0 * 1000.0)
-        self.add_triple(node, "PowerElectronicsUnit.maxP", -storage.kWRated * storage.pctkWRated / 100.0 * 1000.0)
+        self.add_triple(node, "PowerElectronicsUnit.minP", -storage.kWRated * storage.pctCharge / 100.0 * 1000.0)
+        self.add_triple(node, "PowerElectronicsUnit.maxP", storage.kWRated * storage.pctDischarge / 100.0 * 1000.0)
 
         self.add_triple(node, "BatteryUnit.storedE", storage.kWhStored * 1000.0)
         self.add_triple(node, "BatteryUnit.ratedE", storage.kWhRated * 1000.0)


### PR DESCRIPTION
@pseudocubic, These are my suggestions for fixing the `minP` and `maxP` values related to `BatteryUnit`.

1) I think the `minP` should be the negative and it should be related to the Charge maximum power. Being always a negative value makes it clear to be the 'minimum'. Having a `maxP` being negative can be confusing.

2) The `minP` value should be computed based on the `%charge` value given in the OpenDSS definition of the storage unit.

3) The `maxP` value should be computed based on the `%discharge` value given in the OpenDSS definition of the storage unit.

Let's take as an example the following definition in OpenDSS

` New Storage.S1 phases=3 bus1=loadbus.1.2.3 kV=0.4 conn=wye kwrated=60 kwhrated=60 %charge=80 %discharge=60 %effcharge=95 %effdischarge=98 %idlingkw=0 %reserve=20 %stored=10`

The `%charge` and `%discharge` percentages indicate the maximum charging and discharging power of the storage unit. The percentage is computed based on `kwrated`. That is why in the `dss2xml` converter, I think these values are the ones that should be used.

**Note**: The good thing is that if `%charge` and `%discharge`  are not given, then the value defaults automatically to the same (old) `minP` and `maxP`. So, this approach gives a more realistic and useful result/conversion. Validated by testing.