### PR TITLE
Fix cyme phasecode to rowcol

### DIFF
--- a/ravens/xml/cyme.py
+++ b/ravens/xml/cyme.py
@@ -246,7 +246,7 @@ class CymeConverter(RDFGraph):
     def fix_Per_Length_Phase_Impedance_indices(self):
         """
         Expects `Phase Impedance Data` of following format:
-        - Continuous Sequence Numbers
+        - Increasing Sequence Numbers
         - Either specifies triangular matrix, or full matrix
         - First sequence number either starts at 1 or connector_count + 1
         """

--- a/ravens/xml/cyme.py
+++ b/ravens/xml/cyme.py
@@ -265,7 +265,7 @@ class CymeConverter(RDFGraph):
             
             #Validate Sequences are in an acceptable format
             #ignore empty phase impedances
-            if len(sequence_numbers) == 0: 
+            if len(sequence_numbers) == 0 or (all(has_row) and all(has_col)): 
                 continue
 
             #ensure that sequence numbers are continuous

--- a/ravens/xml/cyme.py
+++ b/ravens/xml/cyme.py
@@ -271,10 +271,17 @@ class CymeConverter(RDFGraph):
             #ensure that sequence numbers are continuous
             s_sn = sorted(sequence_numbers) 
             if not all(s_sn[i+1] - s_sn[i] == 1 for i in range(len(s_sn) - 1)):
-                raise ValueError("Phase Sequence Numbers are non-continuous")
-            
+                # Create mapping from old sequence numbers to new contiguous ones
+                seq_mapping = {}
+                for i, old_seq in enumerate(s_sn):
+                    new_seq = s_sn[0] + i  # Start from first value, add index
+                    seq_mapping[old_seq] = new_seq
+                
+                # Update sequence_numbers array with corrected values
+                sequence_numbers = [seq_mapping[seq] for seq in sequence_numbers]
+
             #correct sequence numbers to obey second row indexing
-            seq_jump = s_sn != conductor_count+1 #check to see if sequence starts at conductor count + 1 or if it starts at 1
+            seq_jump = s_sn[0] != conductor_count+1 #check to see if sequence starts at conductor count + 1 or if it starts at 1
             sequence_numbers = [s+(conductor_count)*seq_jump for s in sequence_numbers]
             if min(sequence_numbers) != conductor_count+1:
                 raise ValueError("Initial Phase Impedance sequenceNumber is not of a known acceptable format.")
@@ -309,6 +316,8 @@ class CymeConverter(RDFGraph):
 
 
 if __name__ == "__main__":
-
     # TODO: need synthetic feeder exported from CYME for example
-
+    from ravens import RavensData
+    file_path = "../extern_data/Delaware_Feeder_161_v7_BESS.xml"
+    d = RavensData().import_cyme_cim(file_path)
+    d.dump("../extern_data/tmp.json",indent=2)

--- a/ravens/xml/cyme.py
+++ b/ravens/xml/cyme.py
@@ -5,6 +5,7 @@ from ast import literal_eval
 
 from rdflib.namespace import Namespace, RDF
 from rdflib.term import URIRef
+from rdflib import Literal
 
 from ravens.logging import logger
 from ravens.data import _DEFAULT_CYME_CIM_NAMESPACE, _DEFAULT_CYME_NAMESPACE
@@ -41,6 +42,7 @@ class CymeConverter(RDFGraph):
         self.fix_WireInfo()
         self.fix_Terminal()
         self.fix_Transformer_Terminal_phases()
+        self.fix_Per_Length_Phase_Impedance_indices()
 
         if prune_remaining_cyme:
             self.remove_cyme_objects()
@@ -241,7 +243,74 @@ class CymeConverter(RDFGraph):
                     self.graph.remove((term, self.cim["Terminal.phases"], None))
                     self.graph.add((term, self.cim["Terminal.phases"], combined_phases[seq_num]))
 
+    def fix_Per_Length_Phase_Impedance_indices(self):
+        """
+        Expects `Phase Impedance Data` of following format:
+        - Continuous Sequence Numbers
+        - Either specifies triangular matrix, or full matrix
+        - First sequence number either starts at 1 or connector_count + 1
+        """
+        for PLPI in self.graph.subjects(predicate=RDF.type, object=self.cim["PerLengthPhaseImpedance"]): 
+            conductor_count = int(self.graph.value(subject=PLPI, predicate=self.cim["PerLengthPhaseImpedance.conductorCount"]).value)
+
+            #Scan Sequence List
+            sequence_numbers = []
+            has_row = []
+            has_col = []
+            for phase_info in self.graph.subjects(predicate=self.cim["PhaseImpedanceData.PhaseImpedance"], object=PLPI):
+                sequence_numbers.append(int(self.graph.value(subject=phase_info, predicate=self.cim["PhaseImpedanceData.sequenceNumber"]).value))
+                has_row.append(1 if self.graph.value(subject=phase_info, predicate=self.cim["PhaseImpedanceData.row"]) is not None else 0)
+                has_col.append(1 if self.graph.value(subject=phase_info, predicate=self.cim["PhaseImpedanceData.column"]) is not None else 0)
+            
+            
+            #Validate Sequences are in an acceptable format
+            
+            #ignore empty phase impedances
+            if len(sequence_numbers) == 0: 
+                continue
+
+            #ensure that sequence numbers are continuous
+            s_sn = sorted(sequence_numbers) 
+            if not all(s_sn[i+1] - s_sn[i] == 1 for i in range(len(s_sn) - 1)):
+                raise ValueError("Phase Sequence Numbers are non-continuous")
+            
+            #correct sequence numbers to obey second row indexing
+            seq_jump = s_sn != conductor_count+1 #check to see if sequence starts at conductor count + 1 or if it starts at 1
+            sequence_numbers = [s+(conductor_count)*seq_jump for s in sequence_numbers]
+            if min(sequence_numbers) != conductor_count+1:
+                raise ValueError("Initial Phase Impedance sequenceNumber is not of a known acceptable format.")
+
+            
+            #handle supported matrix specification methods
+
+            rows = []
+            cols = []
+            if len(sequence_numbers) == conductor_count*(conductor_count+1)/2: #handle triangular specification
+                for sn in sequence_numbers:
+                    sn -= conductor_count
+                    rows.append(r := (math.isqrt(8 * (sn-1) + 1) - 1) // 2 + 1)
+                    cols.append((sn-1) - (r-1) * r // 2 + 1)
+                    print(sn,cols[-1],rows[-1])
+            elif len(sequence_numbers) == conductor_count**2: #handle full matrix specification
+                for sn in sequence_numbers:
+                    cols.append((sn - (conductor_count+1))%conductor_count)
+                    rows.append((sn - (conductor_count+1) - cols[-1])/conductor_count + 1)
+                    cols[-1] += 1
+
+            else:  
+                raise ValueError("Initial Phase Impedance sequenceNumber is not of a known acceptable format.")
+                
+
+            #Apply Corrected Row/Cols
+            for i, phase_info in enumerate(self.graph.subjects(predicate=self.cim["PhaseImpedanceData.PhaseImpedance"], object=PLPI)):
+                self.graph.add((phase_info, self.cim["PhaseImpedanceData.column"], Literal(int(cols[i]))))
+                self.graph.add((phase_info, self.cim["PhaseImpedanceData.row"], Literal(int(rows[i]))))
+
+                
+                
+                
+
 
 if __name__ == "__main__":
+
     # TODO: need synthetic feeder exported from CYME for example
-    pass

--- a/ravens/xml/cyme.py
+++ b/ravens/xml/cyme.py
@@ -247,7 +247,7 @@ class CymeConverter(RDFGraph):
         """
         Expects `Phase Impedance Data` of following format:
         - Increasing Sequence Numbers
-        - Either specifies triangular matrix, or full matrix
+        - Either specifies upper triangular matrix, or full matrix
         - First sequence number either starts at 1 or connector_count + 1
         """
         for PLPI in self.graph.subjects(predicate=RDF.type, object=self.cim["PerLengthPhaseImpedance"]): 
@@ -261,7 +261,6 @@ class CymeConverter(RDFGraph):
                 sequence_numbers.append(int(self.graph.value(subject=phase_info, predicate=self.cim["PhaseImpedanceData.sequenceNumber"]).value))
                 has_row.append(1 if self.graph.value(subject=phase_info, predicate=self.cim["PhaseImpedanceData.row"]) is not None else 0)
                 has_col.append(1 if self.graph.value(subject=phase_info, predicate=self.cim["PhaseImpedanceData.column"]) is not None else 0)
-            
             
             #Validate Sequences are in an acceptable format
             #ignore empty phase impedances
@@ -291,10 +290,14 @@ class CymeConverter(RDFGraph):
             rows = []
             cols = []
             if len(sequence_numbers) == conductor_count*(conductor_count+1)/2: #handle triangular specification
-                for sn in sequence_numbers:
-                    sn -= conductor_count
-                    rows.append(r := (math.isqrt(8 * (sn-1) + 1) - 1) // 2 + 1)
-                    cols.append((sn-1) - (r-1) * r // 2 + 1)
+                r = c = 1
+                for i in range(len(sequence_numbers)):
+                    if c > conductor_count:
+                        r +=1
+                        c = r
+                    rows.append(r)
+                    cols.append(c)
+                    c+=1
             elif len(sequence_numbers) == conductor_count**2: #handle full matrix specification
                 for sn in sequence_numbers:
                     cols.append((sn - (conductor_count+1))%conductor_count)

--- a/ravens/xml/cyme.py
+++ b/ravens/xml/cyme.py
@@ -264,7 +264,6 @@ class CymeConverter(RDFGraph):
             
             
             #Validate Sequences are in an acceptable format
-            
             #ignore empty phase impedances
             if len(sequence_numbers) == 0: 
                 continue
@@ -282,7 +281,6 @@ class CymeConverter(RDFGraph):
 
             
             #handle supported matrix specification methods
-
             rows = []
             cols = []
             if len(sequence_numbers) == conductor_count*(conductor_count+1)/2: #handle triangular specification
@@ -290,21 +288,20 @@ class CymeConverter(RDFGraph):
                     sn -= conductor_count
                     rows.append(r := (math.isqrt(8 * (sn-1) + 1) - 1) // 2 + 1)
                     cols.append((sn-1) - (r-1) * r // 2 + 1)
-                    print(sn,cols[-1],rows[-1])
             elif len(sequence_numbers) == conductor_count**2: #handle full matrix specification
                 for sn in sequence_numbers:
                     cols.append((sn - (conductor_count+1))%conductor_count)
                     rows.append((sn - (conductor_count+1) - cols[-1])/conductor_count + 1)
                     cols[-1] += 1
-
             else:  
                 raise ValueError("Initial Phase Impedance sequenceNumber is not of a known acceptable format.")
                 
 
             #Apply Corrected Row/Cols
             for i, phase_info in enumerate(self.graph.subjects(predicate=self.cim["PhaseImpedanceData.PhaseImpedance"], object=PLPI)):
-                self.graph.add((phase_info, self.cim["PhaseImpedanceData.column"], Literal(int(cols[i]))))
                 self.graph.add((phase_info, self.cim["PhaseImpedanceData.row"], Literal(int(rows[i]))))
+                self.graph.add((phase_info, self.cim["PhaseImpedanceData.column"], Literal(int(cols[i]))))
+
 
                 
                 
@@ -314,3 +311,4 @@ class CymeConverter(RDFGraph):
 if __name__ == "__main__":
 
     # TODO: need synthetic feeder exported from CYME for example
+

--- a/ravens/xml/cyme.py
+++ b/ravens/xml/cyme.py
@@ -317,7 +317,4 @@ class CymeConverter(RDFGraph):
 
 if __name__ == "__main__":
     # TODO: need synthetic feeder exported from CYME for example
-    from ravens import RavensData
-    file_path = "../extern_data/Delaware_Feeder_161_v7_BESS.xml"
-    d = RavensData().import_cyme_cim(file_path)
-    d.dump("../extern_data/tmp.json",indent=2)
+    pass


### PR DESCRIPTION
Implemented `def fix_Per_Length_Phase_Impedance_indices()` In `cyme.py`
Function expects `Phase Impedance Data` of following format:
- Increasing Sequence Numbers
- Either specifies upper triangular matrix, or full matrix
- First sequence number either starts at 1 or connector_count + 1

This is meant to handle commonly seen sequence number cases when converting from CYME including:
- Continuous int sequence numbers for a triangular specification of the matrix or for a full matrix specification
- Non continuous but increasing sequence numbers for a for a triangular specification of the matrix or for a full matrix specification

The function will add new `"PhaseImpedanceData.row"` and `"PhaseImpedanceData.column"` for each `PhaseImpedanceData` object whenever ANY instances of row/col are missing.