### PR TITLE
FIX: typo in center tap second phase code

### DIFF
--- a/ravens/xml/opendss2xml.py
+++ b/ravens/xml/opendss2xml.py
@@ -1479,7 +1479,7 @@ class DssExport(RDFGraph):
             if phases == "s1":
                 phase_kind = "s1N"
             elif phases == "s2":
-                phase_kind = "Ns2"
+                phase_kind = "s2N" 
             elif reverse_ground:
                 phase_kind = "N" + phases
             elif wye_ground:


### PR DESCRIPTION
## Fix phase_kind typo in Center Tap Transformer s2 winding

### Summary
This PR corrects a typo in the `phase_kind` attribute for the s2 winding of Center Tap Transformers, supporting ongoing development for downstream modeling and optimization tools.

### Changes
- Updated `phase_kind` from `"Ns2"` to `"s2N"` for the s2 winding

### Impact
This fix ensures consistency in phase naming conventions for Center Tap Transformers used in modeling and optimization workflows.
